### PR TITLE
Add filter command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/wedding/FilterByTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/wedding/FilterByTagCommand.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.commands.wedding;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.WeddingModel;
+import seedu.address.model.person.PersonContainsTagPredicate;
+
+/**
+ * Finds all persons in a wedding with the specified tag and displays them. The tag string must be an exact match
+ * (case-sensitive)
+ */
+public class FilterByTagCommand extends Command {
+
+    public static final String COMMAND_WORD = "filter";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Displays all members with the specific tag "
+            + "(case-sensitive)\n"
+            + "Parameters: TAG\n"
+            + "Example: " + COMMAND_WORD + " guest";
+
+    private final PersonContainsTagPredicate predicate;
+
+    public FilterByTagCommand(PersonContainsTagPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(WeddingModel model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FilterByTagCommand)) {
+            return false;
+        }
+
+        FilterByTagCommand otherFilterCommand = (FilterByTagCommand) other;
+        return predicate.equals(otherFilterCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/wedding/FilterByTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/wedding/FilterByTagCommand.java
@@ -6,7 +6,6 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.WeddingModel;
 import seedu.address.model.person.PersonContainsTagPredicate;
 

--- a/src/main/java/seedu/address/logic/parser/WeddingPlannerParser.java
+++ b/src/main/java/seedu/address/logic/parser/WeddingPlannerParser.java
@@ -20,12 +20,14 @@ import seedu.address.logic.commands.SortWeddingCommand;
 import seedu.address.logic.commands.wedding.AddWeddingCommand;
 import seedu.address.logic.commands.wedding.AddWeddingPersonCommand;
 import seedu.address.logic.commands.wedding.CloseWeddingCommand;
+import seedu.address.logic.commands.wedding.FilterByTagCommand;
 import seedu.address.logic.commands.wedding.FindMemberCommand;
 import seedu.address.logic.commands.wedding.OpenWeddingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.wedding.AddWeddingCommandParser;
 import seedu.address.logic.parser.wedding.AddWeddingPersonCommandParser;
 import seedu.address.logic.parser.wedding.CloseWeddingCommandParser;
+import seedu.address.logic.parser.wedding.FilterByTagCommandParser;
 import seedu.address.logic.parser.wedding.FindMemberCommandParser;
 import seedu.address.logic.parser.wedding.OpenWeddingCommandParser;
 
@@ -104,6 +106,9 @@ public class WeddingPlannerParser {
 
         case FindMemberCommand.COMMAND_WORD:
             return new FindMemberCommandParser().parse(arguments);
+
+        case FilterByTagCommand.COMMAND_WORD:
+            return new FilterByTagCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/wedding/FilterByTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/wedding/FilterByTagCommandParser.java
@@ -7,6 +7,9 @@ import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.PersonContainsTagPredicate;
 
+/**
+ * Parses input arguments and creates a new FilterByTagCommand object
+ */
 public class FilterByTagCommandParser implements Parser<FilterByTagCommand> {
 
     /**

--- a/src/main/java/seedu/address/logic/parser/wedding/FilterByTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/wedding/FilterByTagCommandParser.java
@@ -1,0 +1,26 @@
+package seedu.address.logic.parser.wedding;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.wedding.FilterByTagCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.PersonContainsTagPredicate;
+
+public class FilterByTagCommandParser implements Parser<FilterByTagCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FilterByTagCommand
+     * and returns a FilterByTagCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FilterByTagCommand parse(String args) throws ParseException {
+        String trimArgs = args.trim();
+        if (trimArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterByTagCommand.MESSAGE_USAGE));
+        }
+
+        return new FilterByTagCommand(new PersonContainsTagPredicate(trimArgs));
+    }
+}

--- a/src/main/java/seedu/address/model/person/PersonContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsTagPredicate.java
@@ -1,0 +1,39 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.tag.Tag;
+
+public class PersonContainsTagPredicate implements Predicate<Person> {
+    private final Tag tag;
+
+    public PersonContainsTagPredicate(String tag) {
+        this.tag = new Tag(tag);
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getTags().contains(tag);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof PersonContainsTagPredicate)) {
+            return false;
+        }
+
+        PersonContainsTagPredicate OtherPersonContainsTagPredicate = (PersonContainsTagPredicate) other;
+        return tag.equals(OtherPersonContainsTagPredicate.tag);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("tag", tag).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/PersonContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsTagPredicate.java
@@ -5,6 +5,9 @@ import java.util.function.Predicate;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.tag.Tag;
 
+/**
+ * Tests that a {@code Person}'s {@code Tag} matches the tag given.
+ */
 public class PersonContainsTagPredicate implements Predicate<Person> {
     private final Tag tag;
 
@@ -28,8 +31,8 @@ public class PersonContainsTagPredicate implements Predicate<Person> {
             return false;
         }
 
-        PersonContainsTagPredicate OtherPersonContainsTagPredicate = (PersonContainsTagPredicate) other;
-        return tag.equals(OtherPersonContainsTagPredicate.tag);
+        PersonContainsTagPredicate otherPersonContainsTagPredicate = (PersonContainsTagPredicate) other;
+        return tag.equals(otherPersonContainsTagPredicate.tag);
     }
 
     @Override


### PR DESCRIPTION
Added filter command to allow users to display members based on their tag.

Example usage:
filter staff

Returns a filtered list of Persons with the tag. Note that a wedding has to be opened first, otherwise filter will simply list 0 persons.