### PR TITLE
Fix verbose wedding display on opening selected wedding

### DIFF
--- a/src/main/java/seedu/address/commons/core/LogsCenter.java
+++ b/src/main/java/seedu/address/commons/core/LogsCenter.java
@@ -20,7 +20,7 @@ import java.util.logging.SimpleFormatter;
 public class LogsCenter {
     private static final int MAX_FILE_COUNT = 5;
     private static final int MAX_FILE_SIZE_IN_BYTES = (int) (Math.pow(2, 20) * 5); // 5MB
-    private static final String LOG_FILE = "addressbook.log";
+    private static final String LOG_FILE = "weddingplanner.log";
     private static final Logger logger; // logger for this class
     private static Logger baseLogger; // to be used as the parent of all other loggers created by this class.
     private static Level currentLogLevel = Level.INFO;

--- a/src/main/java/seedu/address/logic/commands/wedding/OpenWeddingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/wedding/OpenWeddingCommand.java
@@ -37,6 +37,6 @@ public class OpenWeddingCommand extends Command {
 
         Wedding weddingToOpen = model.getFilteredWeddingList().get(targetIndex.getZeroBased());
         model.setCurrentWedding(weddingToOpen);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, weddingToOpen));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, weddingToOpen.toPrettyString()));
     }
 }

--- a/src/main/java/seedu/address/model/wedding/Date.java
+++ b/src/main/java/seedu/address/model/wedding/Date.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 
 /**
  * Represents a Wedding's date in the planner.
@@ -18,14 +19,15 @@ public class Date implements Comparable<Date> {
             + "30 September 2025) and must be in the future.";
 
     // Formatter for parsing the input string in DDMMYYYY format.
-    private static final DateTimeFormatter INPUT_FORMATTER = DateTimeFormatter.ofPattern("ddMMyyyy");
-    // Formatter for outputting the date in a friendly format.
-    private static final DateTimeFormatter OUTPUT_FORMATTER = DateTimeFormatter.ofPattern("dd MMMM yyyy");
+    private static final DateTimeFormatter INPUT_FORMATTER = DateTimeFormatter.ofPattern("ddMMuuuu");
+    // Formatter for outputting the date in a prettier format.
+    private static final DateTimeFormatter OUTPUT_FORMATTER = DateTimeFormatter.ofPattern("dd MMMM uuuu");
 
     private static final DateTimeFormatter formatters = new DateTimeFormatterBuilder()
             .appendOptional(INPUT_FORMATTER)
             .appendOptional(OUTPUT_FORMATTER)
-            .toFormatter();
+            .toFormatter()
+            .withResolverStyle(ResolverStyle.STRICT);
 
     public final LocalDate date;
 

--- a/src/main/java/seedu/address/model/wedding/Date.java
+++ b/src/main/java/seedu/address/model/wedding/Date.java
@@ -16,7 +16,7 @@ import java.time.format.ResolverStyle;
 public class Date implements Comparable<Date> {
 
     public static final String MESSAGE_CONSTRAINTS = "Dates should be in the format DDMMYYYY (e.g., 30092025 for "
-            + "30 September 2025) and must be in the future.";
+            + "30 September 2025) and must be in the future and must exist (eg 29022029 is invalid).";
 
     // Formatter for parsing the input string in DDMMYYYY format.
     private static final DateTimeFormatter INPUT_FORMATTER = DateTimeFormatter.ofPattern("ddMMuuuu");

--- a/src/main/java/seedu/address/model/wedding/Wedding.java
+++ b/src/main/java/seedu/address/model/wedding/Wedding.java
@@ -159,4 +159,11 @@ public class Wedding {
                 .toString();
     }
 
+    /**
+     * Alternate String format for printing to the UI
+     */
+    public String toPrettyString() {
+        return this.title.toString();
+    }
+
 }

--- a/src/test/java/seedu/address/model/wedding/DateTest.java
+++ b/src/test/java/seedu/address/model/wedding/DateTest.java
@@ -41,9 +41,15 @@ public class DateTest {
         assertFalse(Date.isValidDate(" ")); // spaces only
         assertFalse(Date.isValidDate("25/12/2025")); // wrong format
         assertFalse(Date.isValidDate("2025-12-25")); // wrong format
+        assertFalse(Date.isValidDate("01011200")); // past date
         assertFalse(Date.isValidDate("25122020")); // past date
         assertFalse(Date.isValidDate("32122025")); // invalid day
         assertFalse(Date.isValidDate("25132025")); // invalid month
+
+        // invalid dates within 1-31 (such as invalid leap years)
+        assertFalse(Date.isValidDate("29022029")); // wrong leap year
+        assertFalse(Date.isValidDate("31062025")); // day does not exist
+        assertFalse(Date.isValidDate("31042027")); // day does not exist
 
         // valid dates (future dates in DDMMYYYY format)
         assertTrue(Date.isValidDate("25122025")); // Christmas 2025


### PR DESCRIPTION
Added a toPrettyString method in the Wedding class to interface with the open wedding output on the UI while keeping the standard toString for compatibility with the storage.